### PR TITLE
Fix package version in user agent

### DIFF
--- a/src/lib/useragentbuilder.ts
+++ b/src/lib/useragentbuilder.ts
@@ -10,7 +10,7 @@ function version() {
 export class UserAgentBuilder {  
   static Build() {
     let pkg = { version: 'DEV' }
-    let pkgconfig = resolve(__dirname, '..', 'package.json');
+    let pkgconfig = resolve(__dirname, '..', '..', 'package.json');
     if (fs.existsSync(pkgconfig)) {
       pkg = JSON.parse(fs.readFileSync(pkgconfig, 'utf8'))
     }


### PR DESCRIPTION
The package is reporting `DEV` right now as it has the incorrect `package.json` location in the user agent builder. This fix corrects that bug.
